### PR TITLE
Bump dmd to 2.074.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ services:
 
 script:
   - docker build -t stonemaster/dlang-tour-rdmd .
+deploy:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker push stonemaster/dlang-tour-rdmd

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 MAINTAINER "André Stein <andre.stein.1985@gmail.com>"
 
 # Version updates here
-ENV VERSION "2.071.0"
+ENV VERSION "2.074.0"
 
 RUN apt-get update && apt-get install --no-install-recommends -y wget libc6-dev xdg-utils gcc libcurl3  && \
     wget http://downloads.dlang.org/releases/2.x/${VERSION}/dmd_${VERSION}-0_amd64.deb -O /dmd.deb && \


### PR DESCRIPTION
Bumps to 2.073.0 - this is interesting because e.g. compiling ~/dlang/phobos/std/algorithm/comparison.d took 1.9s on 2.071.0, whereas with 2.073.0 it takes only 0.8s

This is based on the fact that before 2.072 `rdmd` used to compile the main file twice, see e.g.

https://github.com/dlang/tools/pull/194
https://github.com/dlang/tools/pull/207