### PR TITLE
Use after_success stage instead of deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 
 script:
   - docker build -t stonemaster/dlang-tour-rdmd .
-deploy:
+
+after_success:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker push stonemaster/dlang-tour-rdmd


### PR DESCRIPTION
> To deploy to a custom or unsupported provider, use the after-success build stage or script provider.

Sorry, my fault -> will immediately merge this as "bug fix".
FYI: nothing is broken as the script is only supposed to upload a new image.