### PR TITLE
Use dmd -run instead of rdmd

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ set -o pipefail
 cd /sandbox
 echo "$*" | base64 -d > onlineapp.d
 
-exec timeout -s KILL ${TIMEOUT:-20} rdmd onlineapp.d | tail -n100
+exec timeout -s KILL ${TIMEOUT:-20} dmd -run onlineapp.d | tail -n100


### PR DESCRIPTION
Even though we deviate a bit from the name, there's absolutely no need to use rdmd here. It's just slow as  as `rdmd` runs `dmd` twice. Thus this will make it about 40% faster :)

See https://github.com/dlang/tools/pull/194 and https://github.com/dlang/tools/pull/191 (the PR unfortunately got reverted).

And https://github.com/dlang-tour/dlang-tour/pull/528