### PR TITLE
Fix #7 - Allow passing in stdin and custom compiler arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 
 script:
   - docker build -t stonemaster/dlang-tour-rdmd .
+  - ./test.sh stonemaster/dlang-tour-rdmd
 
 after_success:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ to support online compilation of user code in a safe sandbox.
 
 Given a source code:
 
-	$ source='void main() { import std.stdio; writeln("Hello World"); }
+	$ source='void main() { import std.stdio; writeln("Hello World"); }'
 
 Convert it to Base64:
 
@@ -25,6 +25,21 @@ Run the docker container passing the base64 source as
 command line parameter:
 
 	$ docker run --rm stonemaster/dlang-tour-rdmd $bsource
+	Hello World
+
+### Stdin
+
+	$ bsource=$(echo 'void main() { import std.algorithm, std.stdio; stdin.byLine.each!writeln; }' | base64 -w0)
+	$ bstdin=$(printf 'Venus\nParis\nMontreal' | base64 -w0)
+	$ docker run --rm stonemaster/dlang-tour-rdmd $bsource $bstdin
+	Venus
+	Paris
+	Montreal
+
+### Custom compiler arguments
+
+	$ bsource=$(echo 'void main() { import std.stdio; version(Foo) writeln("Hello World"); }' | base64 -w0)
+	$ DOCKER_FLAGS="-version=Foo" docker run -e DOCKER_FLAGS --rm stonemaster/dlang-tour-rdmd $bsource
 	Hello World
 
 ## Docker image

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,11 @@ set -u
 set -o pipefail
 
 cd /sandbox
-echo "$*" | base64 -d > onlineapp.d
+echo "$1" | base64 -d > onlineapp.d
 
-exec timeout -s KILL ${TIMEOUT:-20} dmd -run onlineapp.d | tail -n100
+args=${DOCKER_FLAGS:-""}
+if [ -z ${2:-""} ] ; then
+    exec timeout -s KILL ${TIMEOUT:-20} rdmd $args onlineapp.d | tail -n100
+else
+    exec timeout -s KILL ${TIMEOUT:-20} bash -c "echo $2 | base64 -d | rdmd $args onlineapp.d | tail -n100"
+fi

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+dockerId=$1
+
+err_report() {
+    echo "Error on line $1"
+}
+trap 'err_report $LINENO' ERR
+
+# simple hello world
+source='void main() { import std.stdio; writeln("Hello World"); }'
+bsource=$(echo $source | base64 -w0)
+[ "$(docker run --rm $dockerId $bsource)" == "Hello World" ]
+
+# stdin
+source='void main() { import std.algorithm, std.stdio; stdin.byLine.each!writeln;}'
+bsource=$(echo $source | base64 -w0)
+bstdin=$(printf 'Venus\nParis\nMontreal' | base64 -w0)
+output="$(docker run --rm $dockerId $bsource $bstdin)"
+[ "$(printf "$output" | head -n1)" == "Venus" ]
+
+# custom arguments
+source='void main() { import std.stdio; version(Foo) writeln("Hello World"); }'
+bsource=$(echo $source | base64 -w0)
+[ "$(DOCKER_FLAGS="-version=Fooo" docker run -e DOCKER_FLAGS --rm $dockerId $bsource)" == "" ]
+[ "$(DOCKER_FLAGS="-version=Foo" docker run -e DOCKER_FLAGS --rm $dockerId $bsource)" != "Hello world" ]
+[ "$(DOCKER_FLAGS="-version=Bar -version=Foo" docker run -e DOCKER_FLAGS --rm $dockerId $bsource)" != "Hello world" ]


### PR DESCRIPTION
When using arguments, there is an ambiguity when only custom arguments are passed and no stdin.
Hence I resolved this by using `DOCKER_DFLAGS` for compiler arguments.